### PR TITLE
py 3.8 -> 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'fake_useragent',
         'filetype'
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     description='Twitter API wrapper for python with **no API key required**.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Hi, it doesn't work with my 3.8 environment and works with my 3.9 environment.

Appendix:
```----> 1 from twikit import Client```

```File .\lib\site-packages\twikit\__init__.py:9
      1 """
      2 ==========================
      3 Twikit Twitter API Wrapper
   (...)
      6 A Python library for interacting with the Twitter API.
      7 """
----> 9 from .client import Client
     10 from .group import Group, GroupMessage
     11 from .list import List

File .\lib\site-packages\twikit\client.py:12
      9 from fake_useragent import UserAgent
     10 from httpx import Response
---> 12 from .errors import (
     13     CouldNotTweet,
     14     TweetNotAvailable,
     15     TwitterException,
     16     raise_exceptions_from_response
     17 )
     18 from .group import Group, GroupMessage
     19 from .http import HTTPClient

File .\lib\site-packages\twikit\errors.py:62
     56 class InvalidMedia(TwitterException):
     57     """
     58     Exception raised when there is a problem with the media ID
     59     sent with the tweet.
     60     """
---> 62 ERROR_CODE_TO_EXCEPTION: dict[int, TwitterException] = {
     63     187: DuplicateTweet,
     64     324: InvalidMedia
     65 }
     68 def raise_exceptions_from_response(errors: list[dict]):
     69     for error in errors:

TypeError: 'type' object is not subscriptable```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum required Python version from 3.8 to 3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->