### PR TITLE
Trends API parameter

### DIFF
--- a/twikit/client.py
+++ b/twikit/client.py
@@ -2362,7 +2362,8 @@ class Client:
         category: Literal[
             'trending', 'for-you', 'news', 'sports', 'entertainment'
         ],
-        count: int = 20
+        count: int = 20,
+        retry: bool = True
     ) -> list[Trend]:
         """
         Retrieves trending topics on Twitter.
@@ -2378,6 +2379,8 @@ class Client:
             - 'entertainment': Entertainment-related trends.
         count : :class:`int`, default=20
             The number of trends to retrieve.
+        retry : :class:`bool`, default=True
+            If no trends are fetched continuously retry to fetch trends.
 
         Returns
         -------
@@ -2415,9 +2418,11 @@ class Client:
         ]
 
         if not entries:
+            if not retry:
+                return []
             # Recall the method again, as the trend information
             # may not be returned due to a Twitter error.
-            return self.get_trends(category, count)
+            return self.get_trends(category, count, retry)
 
         items = entries[-1]['content']['timelineModule']['items']
 

--- a/twikit/client.py
+++ b/twikit/client.py
@@ -2397,6 +2397,7 @@ class Client:
         if category in ['news', 'sports', 'entertainment']:
             category += '_unified'
         params = {
+            'candidate_source': 'trends',
             'count': count,
             'include_page_configuration': True,
             'initial_tab_id': category

--- a/twikit/twikit_async/client.py
+++ b/twikit/twikit_async/client.py
@@ -2415,6 +2415,7 @@ class Client:
         if category in ['news', 'sports', 'entertainment']:
             category += '_unified'
         params = {
+            'candidate_source': 'trends',
             'count': count,
             'include_page_configuration': True,
             'initial_tab_id': category

--- a/twikit/twikit_async/client.py
+++ b/twikit/twikit_async/client.py
@@ -2380,7 +2380,8 @@ class Client:
         category: Literal[
             'trending', 'for-you', 'news', 'sports', 'entertainment'
         ],
-        count: int = 20
+        count: int = 20,
+        retry: bool = True
     ) -> list[Trend]:
         """
         Retrieves trending topics on Twitter.
@@ -2396,6 +2397,8 @@ class Client:
             - 'entertainment': Entertainment-related trends.
         count : :class:`int`, default=20
             The number of trends to retrieve.
+        retry : :class:`bool`, default=True
+            If no trends are fetched continuously retry to fetch trends.
 
         Returns
         -------
@@ -2433,9 +2436,11 @@ class Client:
         ]
 
         if not entries:
+            if not retry:
+                return []
             # Recall the method again, as the trend information
             # may not be returned due to a Twitter error.
-            return await self.get_trends(category, count)
+            return await self.get_trends(category, count, retry)
 
         items = entries[-1]['content']['timelineModule']['items']
 


### PR DESCRIPTION
Hello and many thanks for your awesome work 👋

I always encounter #53 while trying to fetch trends.

The solution I found was to add another request parameter in the first commit of this pull request, following my comment in another repository https://github.com/trevorhobenshield/twitter-api-client/issues/56#issuecomment-1718249361.

Nevertheless, this only works for the `trending` category and not for `for-you`, `news`, `sports`, and `entertainment`. I don't have a solution for the rest, so feel free to close this merge request if it doesn't suit you.

In the second commit, I made continuous refetching of trends optional, controlled by an argument.

P.S. Just for your information, I think that previous trends endpoint is no longer used when using e.g. my browser for my Twitter account. https://github.com/d60/twikit/blob/7bccd7fb43b3ec4c4ae1b11a58224fb622ad10d3/twikit/utils.py#L98

P.P.S. Mentioning vladkens/twscrape#73 just for their reference, in case this helps them too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `get_trends` function with an optional `retry` parameter, giving users control over retry behavior when fetching trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->