### PR TITLE
Support custom trends API request parameters

### DIFF
--- a/twikit/client.py
+++ b/twikit/client.py
@@ -2369,7 +2369,8 @@ class Client:
             'trending', 'for-you', 'news', 'sports', 'entertainment'
         ],
         count: int = 20,
-        retry: bool = True
+        retry: bool = True,
+        additional_request_params: dict = {}
     ) -> list[Trend]:
         """
         Retrieves trending topics on Twitter.
@@ -2386,7 +2387,11 @@ class Client:
         count : :class:`int`, default=20
             The number of trends to retrieve.
         retry : :class:`bool`, default=True
-            If no trends are fetched continuously retry to fetch trends.
+            If no trends are fetched, continuously retry to fetch trends.
+        additional_request_params : :class:`dict`, default={}
+            Parameters to be added on top of the existing trends API parameters.
+            Typically, it is used as `additional_request_params =
+            {'candidate_source': 'trends'}` when this function doesn't work otherwise.
 
         Returns
         -------
@@ -2409,7 +2414,7 @@ class Client:
             'count': count,
             'include_page_configuration': True,
             'initial_tab_id': category
-        }
+        } | additional_request_params
         response = self.http.get(
             Endpoint.TREND,
             params=params,
@@ -2427,7 +2432,7 @@ class Client:
                 return []
             # Recall the method again, as the trend information
             # may not be returned due to a Twitter error.
-            return self.get_trends(category, count, retry)
+            return self.get_trends(category, count, retry, additional_request_params)
 
         items = entries[-1]['content']['timelineModule']['items']
 

--- a/twikit/twikit_async/client.py
+++ b/twikit/twikit_async/client.py
@@ -2387,7 +2387,8 @@ class Client:
             'trending', 'for-you', 'news', 'sports', 'entertainment'
         ],
         count: int = 20,
-        retry: bool = True
+        retry: bool = True,
+        additional_request_params: dict = {}
     ) -> list[Trend]:
         """
         Retrieves trending topics on Twitter.
@@ -2404,7 +2405,11 @@ class Client:
         count : :class:`int`, default=20
             The number of trends to retrieve.
         retry : :class:`bool`, default=True
-            If no trends are fetched continuously retry to fetch trends.
+            If no trends are fetched, continuously retry to fetch trends.
+        additional_request_params : :class:`dict`, default={}
+            Parameters to be added on top of the existing trends API parameters.
+            Typically, it is used as `additional_request_params =
+            {'candidate_source': 'trends'}` when this function doesn't work otherwise.
 
         Returns
         -------
@@ -2427,7 +2432,7 @@ class Client:
             'count': count,
             'include_page_configuration': True,
             'initial_tab_id': category
-        }
+        } | additional_request_params
         response = (await self.http.get(
             Endpoint.TREND,
             params=params,
@@ -2445,7 +2450,7 @@ class Client:
                 return []
             # Recall the method again, as the trend information
             # may not be returned due to a Twitter error.
-            return await self.get_trends(category, count, retry)
+            return await self.get_trends(category, count, retry, additional_request_params)
 
         items = entries[-1]['content']['timelineModule']['items']
 


### PR DESCRIPTION
Hello and thanks for merging #61! Unfortunately, it turns out that for some people the trends request parameter `candidate_source=trends` is needed and for others it doesn't work.

My proposal is to just allow the specification of additional request parameters for the trends API. For example

```python
from twikit import Client

client = Client('en-US')
client.set_cookies({
    'auth_token': REDACTED,
    'ct0': REDACTED
})

print('Without additional parameter')
for category in ['trending', 'for-you', 'news', 'sports', 'entertainment']:
    trends = client.get_trends(category, retry=False)
    if trends:
        print(f'Successfully fetched trends for the {category} category')

print('With additional parameter')
for category in ['trending', 'for-you', 'news', 'sports', 'entertainment']:
    trends = client.get_trends(category, retry=False, additional_request_params={'candidate_source':'trends'})
    if trends:
        print(f'Successfully fetched trends for the {category} category')
```

This is the results I get when executing the above from a Greek IP. _Edit: The same results are produced from a German IP too._

```
Without additional parameter
With additional parameter
Successfully fetched trends for the trending category
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the trends retrieval function to accept additional user-defined parameters for more customized API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->