### PR TITLE
Fixing `KeyError: 'card'` in `Tweet`

### DIFF
--- a/twikit/tweet.py
+++ b/twikit/tweet.py
@@ -173,14 +173,12 @@ class Tweet:
             i['text'] for i in hashtags
         ]
 
-        if (
-            'card' in data and
-            'legacy' in data['card'] and
-            'name' in data['card']['legacy'] and
-            data['card']['legacy']['name'].startswith('poll')
-        ):
-            self._poll_data = data['card']
-        else:
+        try:
+            if data['card']['legacy']['name'].startswith('poll'):
+                self._poll_data = data['card']
+            else:
+                self._poll_data = None
+        except (KeyError, AttributeError):
             self._poll_data = None
 
     @property

--- a/twikit/twikit_async/tweet.py
+++ b/twikit/twikit_async/tweet.py
@@ -170,14 +170,12 @@ class Tweet:
             i['text'] for i in hashtags
         ]
 
-        if all([
-            'card' in data,
-            'legacy' in data['card'],
-            'name' in data['card']['legacy'],
-            data['card']['legacy']['name'].startswith('poll')
-        ]):
-            self._poll_data = data['card']
-        else:
+        try:
+            if data['card']['legacy']['name'].startswith('poll'):
+                self._poll_data = data['card']
+            else:
+                self._poll_data = None
+        except (KeyError, AttributeError):
             self._poll_data = None
 
     @property


### PR DESCRIPTION
This fixes the problem of `KeyError: 'card'` in Tweet initialization (#68) by try except of extracting the `card` to `_poll_data` and setting it to None in case of KeyError. Since error handling in Python is very cheap - I think this is a reasonable way to deal with the problem