### PR TITLE
Handle Community Note data existing without note

### DIFF
--- a/twikit/tweet.py
+++ b/twikit/tweet.py
@@ -162,14 +162,14 @@ class Tweet:
                            if 'views' in data else None)
         self.has_community_notes: bool = data.get('has_birdwatch_notes')
 
+        self.community_note = None
         if 'birdwatch_pivot' in data:
             community_note_data = data['birdwatch_pivot']
-            self.community_note = {
-                'id': community_note_data['note']['rest_id'],
-                'text': community_note_data['subtitle']['text']
-            }
-        else:
-            self.community_note = None
+            if 'note' in community_note_data:
+                self.community_note = {
+                    'id': community_note_data['note']['rest_id'],
+                    'text': community_note_data['subtitle']['text']
+                }
 
         if note_tweet_results:
             hashtags_ = find_dict(note_tweet_results, 'hashtags')


### PR DESCRIPTION
When I had been testing this library, I got error messages related to the Community Notes data. It turns out, as a Community Notes contributer, I get the `birdwatch_pivot` property attached to the tweets I view if there are any Community Notes on the tweet, even if none of them are visible.

My change simply checks for the existence of the `note` property on the note before getting its data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the assignment of community notes in tweets to include more detailed information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->