### PR TITLE
Unable to receive tweet notifications

### DIFF
--- a/twikit/client.py
+++ b/twikit/client.py
@@ -4456,6 +4456,8 @@ class Client(BaseClient):
             Mentions: Notifications with mentions
         count : :class:`int`, default=40
             Number of notifications to retrieve.
+        retreive_inbox : :class:`bool`, default=False,
+            Receive the entire Notification inbox
 
         Returns
         -------

--- a/twikit/client.py
+++ b/twikit/client.py
@@ -4456,7 +4456,7 @@ class Client(BaseClient):
             Mentions: Notifications with mentions
         count : :class:`int`, default=40
             Number of notifications to retrieve.
-        retreive_inbox : :class:`bool`, default=False,
+        retrieve_inbox : :class:`bool`, default=False,
             Receive the entire Notification inbox
 
         Returns


### PR DESCRIPTION
Related to this issue: https://github.com/d60/twikit/issues/138

I added a new parameter for the ``Client.get_notifications`` method (it's retreive_inbox).
```py
def get_notifications(
        self,
        type: Literal['All', 'Verified', 'Mentions'],
        count: int = 40,
        retreive_inbox: bool = False,
        cursor: str | None = None
    ) -> Result[Notification]:
```

In order to receive all notifications from the 'tweets' key (of the API endpoint response) and not from 'notifications' key.

It seems to work but I have to sign in to Twitter (from web browser) in order to refresh the notifications from the API response, I don't know why...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced notification handling with a new option to retrieve additional inbox notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->