### PR TITLE
Auto-resolve connection with phone number

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -430,7 +430,7 @@ class Client:
             await flow.execute_task({
                 'subtask_id': 'LoginAcid',
                 'enter_text': {
-                    'text': input('>>> '),
+                    'text': input('>>> ') if auth_info_2 is None else auth_info_2,
                     'link': 'next_link'
                 }
             })


### PR DESCRIPTION
This pull will allow the user to automaticly resolve the "LoginAcid" part (simiar to the "LoginEnterAlternateIdentifierSubtask") by using the `auth_info_2` if it's specified.