### PR TITLE
Create Tweet Errors

### DIFF
--- a/twikit/errors.py
+++ b/twikit/errors.py
@@ -94,6 +94,21 @@ class AccountLocked(TwitterException):
     Exception raised when the account is locked (very likey is Arkose challenge).
     """
 
+class CreateTweetFailed(TwitterException):
+    """
+    Exception raised when create_tweet fails.
+    """
+
+class CreateTweetDuplicate(CreateTweetFailed):
+    """
+    Exception raised when create_tweet create a duplicate tweet in a short period of time.
+    """
+
+class CreateTweetMaxLengthReached(CreateTweetFailed):
+    """
+    Exception raised when create_tweet try to c.
+    """
+
 ERROR_CODE_TO_EXCEPTION: dict[int, TwitterException] = {
     187: DuplicateTweet,
     324: InvalidMedia


### PR DESCRIPTION

## Description

### Context
This PR introduces error handling for the `create_tweet` function. Currently, the function does not properly handle potential errors that may occur during tweet creation, such as the length of a tweet and the duplication of a tweet in a short period. This update aims to make the function more robust and improve overall reliability.
Currently, the error provided when `create_tweet` fails is a `KeyError` exception which is too general to troubleshoot, with this update we try to give more meaningful error to the developer

### Changes
- Added a private function `_switch_error`
	- `_switch_error` at the moment manage 2 exception (Duplicated tweet in short period of time, length of the tweet)
	- When error occures but it's not handled program, before crash, print `response` to make sure that the developer notice the error and can report the `known issue`
- Added 2 errors in `errors.py`
