### PR TITLE
Fix check for screen name when building friendships request for V11 client class

### DIFF
--- a/twikit/client/v11.py
+++ b/twikit/client/v11.py
@@ -386,7 +386,7 @@ class V11Client:
         params = {'count': count}
         if user_id is not None:
             params['user_id'] = user_id
-        elif user_id is not None:
+        elif screen_name is not None:
             params['screen_name'] = screen_name
 
         if cursor is not None:


### PR DESCRIPTION
# What

Adjust how the payload is created when fetching friendships

# Why

Currently implementation overrides the `screen_name` in the payload to `None` if `user_id` is not also supplied

# Details

The check https://github.com/d60/twikit/blob/6d19016f7809dc0458994e1504edb7de3ae57504/twikit/client/v11.py#L389 should be checking for presence of `screen_name` and not `user_id` 