### PR TITLE
Fix: Correct handling of note tweets in create_tweet method

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -1238,7 +1238,10 @@ class Client:
             reply_to, attachment_url, community_id, share_with_followers,
             richtext_options, edit_tweet_id, limit_mode
         )
-        _result = response['data']['create_tweet']['tweet_results']
+        if is_note_tweet:
+            _result = response['data']['notetweet_create']['tweet_results']
+        else:
+            _result = response['data']['create_tweet']['tweet_results']
         if not _result:
             raise_exceptions_from_response(response['errors'])
             raise CouldNotTweet(


### PR DESCRIPTION
- Fixed the conditional check for `is_note_tweet` in the `create_tweet` method to ensure proper handling of note tweets.

## Summary by Sourcery

Fix the conditional logic in the create_tweet method to ensure note tweets are processed correctly.

Bug Fixes:
- Correct the handling of note tweets in the create_tweet method by fixing the conditional check for is_note_tweet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tweet creation process to support community notes alongside standard tweets.
  
- **Documentation**
	- Updated documentation strings for the `create_tweet` method to clarify parameters and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->