### PR TITLE
Update client.py

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -735,7 +735,11 @@ class Client:
             if not item['entryId'].startswith(('tweet', 'search-grid')):
                 continue
 
-            tweet = tweet_from_data(self, item)
+            try:
+                tweet = tweet_from_data(self, item)
+            except KeyError:
+                tweet = None
+                
             if tweet is not None:
                 results.append(tweet)
 


### PR DESCRIPTION
sometimes the tweet retrieved from X would be malformatted and doesn't have the key "core", this can due to multiple reasons like the the original retweeted user has deleted the account