### PR TITLE
Add configurable API URL support for Capsolver captcha solver

### DIFF
--- a/twikit/_captcha/capsolver.py
+++ b/twikit/_captcha/capsolver.py
@@ -31,8 +31,9 @@ class Capsolver(CaptchaSolver):
     max_attempts : :class:`int`, default=3
         The maximum number of attempts to solve the captcha.
     get_result_interval : :class:`float`, default=1.0
-
     use_blob_data : :class:`bool`, default=False
+    api_url : :class:`str`, default='https://api.capsolver.com'
+        Base URL for Capsolver API. Can be changed to use alternative API endpoints.
     """
 
     def __init__(
@@ -40,12 +41,14 @@ class Capsolver(CaptchaSolver):
         api_key: str,
         max_attempts: int = 3,
         get_result_interval: float = 1.0,
-        use_blob_data: bool = False
+        use_blob_data: bool = False,
+        api_url: str = 'https://api.capsolver.com'
     ) -> None:
         self.api_key = api_key
         self.get_result_interval = get_result_interval
         self.max_attempts = max_attempts
         self.use_blob_data = use_blob_data
+        self.api_url = api_url.rstrip('/')  
 
     def create_task(self, task_data: dict) -> dict:
         data = {
@@ -53,7 +56,7 @@ class Capsolver(CaptchaSolver):
             'task': task_data
         }
         response = httpx.post(
-            'https://api.capsolver.com/createTask',
+            f'{self.api_url}/createTask',
             json=data,
             headers={'content-type': 'application/json'}
         ).json()
@@ -65,7 +68,7 @@ class Capsolver(CaptchaSolver):
             'taskId': task_id
         }
         response = httpx.post(
-            'https://api.capsolver.com/getTaskResult',
+            f'{self.api_url}/getTaskResult',
             json=data,
             headers={'content-type': 'application/json'}
         ).json()


### PR DESCRIPTION
# Add support for custom API endpoints in Capsolver

This commit enhances the Capsolver class by adding support for custom API endpoints. Users can now specify an alternative API URL when initializing the Capsolver instance, allowing for greater flexibility when working with different Capsolver API providers or self-hosted solutions.

Key changes:
- Added a new `api_url` parameter to the Capsolver constructor with a default value of 'https://api.capsolver.com'
- Updated the documentation to reflect the new parameter
- Modified the `create_task` and `get_task_result` methods to use the custom API URL
- Added trailing slash handling to ensure proper URL formatting

Example usage:
```python
# Standard API
solver = Capsolver(api_key='your_api_key')

# Custom API endpoint
solver = Capsolver(
    api_key='your_api_key',
    api_url='https://custom-api.capsolver.com'
)
```
