### PR TITLE
gql: fix bookmark_folders_slice malformed variables

### DIFF
--- a/twikit/client/gql.py
+++ b/twikit/client/gql.py
@@ -441,7 +441,6 @@ class GQLClient:
         variables = {}
         if cursor is not None:
             variables['cursor'] = cursor
-        variables = {'variables': variables}
         return await self.gql_get(Endpoint.BOOKMARK_FOLDERS_SLICE, variables)
 
     async def edit_bookmark_folder(self, folder_id, name):


### PR DESCRIPTION
1 line fix.

variables was redeclared with nested variables. this caused an infinite loop on next() calls as the variables were ignored due to being malformed.

really tough one to trace down. checked if it happened anywhere else and thankfully it does not.

thanks for the lib