### PR TITLE
Unpack home-conversation entries in get_latest_timeline

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -2064,13 +2064,21 @@ class Client:
         next_cursor = items[-1]['content']['value']
         results = []
 
-        for item in items:
-            if 'itemContent' not in item['content']:
-                continue
+        def handle_item(item):
             tweet = tweet_from_data(self, item)
-            if tweet is None:
-                continue
-            results.append(tweet)
+            if tweet is not None:
+                results.append(tweet)
+
+        for item in items:
+            if 'items' in item['content']: # home-conversation entries
+                for item in item['content']['items']:
+                    if 'itemContent' not in item['item']:
+                        continue
+                    handle_item(item)
+            else: # tweet entries
+                if 'itemContent' not in item['content']:
+                    continue
+                handle_item(item)
 
         return Result(
             results,


### PR DESCRIPTION
Closes #336

Tested on live Twitter against my test case and works without issues. If you want to test it on your end as well, check if posts contained in `home-conversation` entries are indeed included in the output (whether or not you have those in your account's timeline depends on who you follow I believe, but I think they are pretty common).