### PR TITLE
Fix KeyError legacy['can_media_tag'] in User class

### DIFF
--- a/twikit/user.py
+++ b/twikit/user.py
@@ -106,7 +106,7 @@ class User:
         self.verified: bool = legacy['verified']
         self.possibly_sensitive: bool = legacy['possibly_sensitive']
         self.can_dm: bool = legacy['can_dm']
-        self.can_media_tag: bool = legacy['can_media_tag']
+        self.can_media_tag: bool = legacy.get('can_media_tag', False)
         self.want_retweets: bool = legacy['want_retweets']
         self.default_profile: bool = legacy['default_profile']
         self.default_profile_image: bool = legacy['default_profile_image']


### PR DESCRIPTION
Twitter returned data where it caused a KeyError on `legacy['can_media_tag']`, I do not have the particular test user profile, it was lost.. but I did pass through the same data a second time with this fix and no error occurred ever again.

## Summary by Sourcery

Bug Fixes:
- Fix a KeyError in the User class by using the get method for 'can_media_tag' with a default value of False.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of a user media tagging setting by providing a safe default. This change prevents potential errors when the configuration is missing, ensuring smoother operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->