### PR TITLE
feat: add `edit_tweet_ids` property to Tweet class

### DIFF
--- a/twikit/guest/tweet.py
+++ b/twikit/guest/tweet.py
@@ -68,6 +68,8 @@ class Tweet:
         Indicates if the tweet is eligible for editing.
     edits_remaining : :class:`int`
         The remaining number of edits allowed for the tweet.
+    edit_tweet_ids : :class:`list`[:class:`int`]
+        List of tweet IDs representing the edit history of the tweet.
     reply_to: list[:class:`Tweet`] | None
         A list of Tweet objects representing the tweets to which to reply.
     related_tweets : list[:class:`Tweet`] | None
@@ -114,6 +116,7 @@ class Tweet:
         self._place_data = legacy.get('place')
         self.bookmark_count: int = legacy.get('bookmark_count')
         self.bookmarked: bool = legacy.get('bookmarked')
+        self.edit_tweet_ids: list[int] = data['edit_control'].get('edit_tweet_ids', [])
         self.editable_until_msecs: int = data['edit_control'].get('editable_until_msecs')
         self.is_translatable: bool = data.get('is_translatable')
         self.is_edit_eligible: bool = data['edit_control'].get('is_edit_eligible')

--- a/twikit/tweet.py
+++ b/twikit/tweet.py
@@ -75,6 +75,8 @@ class Tweet:
         Indicates if the tweet is eligible for editing.
     edits_remaining : :class:`int`
         The remaining number of edits allowed for the tweet.
+    edit_tweet_ids : :class:`list`[:class:`int`]
+        List of tweet IDs representing the edit history of the tweet.
     replies: Result[:class:`Tweet`] | None
         Replies to the tweet.
     reply_to: list[:class:`Tweet`] | None
@@ -172,7 +174,7 @@ class Tweet:
 
     @property
     def edit_tweet_ids(self) -> list[int]:
-        return self._data['edit_control'].get('edit_tweet_ids')
+        return self._data['edit_control'].get('edit_tweet_ids', [])
 
     @property
     def editable_until_msecs(self) -> int:

--- a/twikit/tweet.py
+++ b/twikit/tweet.py
@@ -171,6 +171,10 @@ class Tweet:
         return self._legacy.get('bookmarked')
 
     @property
+    def edit_tweet_ids(self) -> list[int]:
+        return self._data['edit_control'].get('edit_tweet_ids')
+
+    @property
     def editable_until_msecs(self) -> int:
         return self._data['edit_control'].get('editable_until_msecs')
 


### PR DESCRIPTION
Exposes the list of edit tweet IDs from the `edit_control` field in tweet data.

## Summary by Sourcery

New Features:
- Introduce `edit_tweet_ids` property to retrieve the list of edit tweet IDs from the tweet's edit control data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability that allows users to access a list of identifiers for edited tweets.
  - Existing functionality related to tweet editing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->