### PR TITLE
Adjust frame time calculation for better stability 

### DIFF
--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -131,6 +131,7 @@ class ClientTransaction:
         row_index = key_bytes[self.DEFAULT_ROW_INDEX] % 16
         frame_time = reduce(lambda num1, num2: num1*num2,
                             [key_bytes[index] % 16 for index in self.DEFAULT_KEY_BYTES_INDICES])
+        frame_time = round(frame_time / 10) * 10
         arr = self.get_2d_array(key_bytes, response)
         frame_row = arr[row_index]
 


### PR DESCRIPTION
I am replying the same approach used in @Lqm1's `x-client-transaction-id` [library](https://github.com/Lqm1/x-client-transaction-id). This change is mentioned to reduce the frequency of the `404 Not Found` error.

The original author implemented this same fix in the following [commit](https://github.com/Lqm1/x-client-transaction-id/commit/9838903a22a7633b48a38d20b39621b23827ff20).