### PR TITLE
Added functionality for fetching `user_mentions`

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -785,6 +785,20 @@ class Client:
             previous_cursor
         )
 
+    async def get_user_mentions(
+        self,
+        handle: str,
+        search_count: int = 20
+    ) -> List[Tweet]:
+        result = await self.search_tweet(f"@{handle}", "Latest", count=search_count)
+        mentions = []
+        for tweet in result:
+            tweet_id = str(tweet.id)
+            if f"@{handle.lower()}" in (tweet.full_text or tweet.text or "").strip().lower():
+                mentions.append((tweet_id, tweet))
+        mentions.sort(key=lambda x: int(x[0]))
+        return mentions
+
     async def search_user(
         self,
         query: str,

--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -790,6 +790,32 @@ class Client:
         handle: str,
         search_count: int = 20
     ) -> List[Tweet]:
+        """
+        Fetches user mentions via search method.
+
+        Parameters
+        ----------
+        handle : :class:`str`
+            The target user handle (eg: 5mknc5, elonmusk).
+        search_count : :class:`int`, default=20
+            The number of latest tweets to retrieve in each request.
+
+        Returns
+        -------
+        List[:class:`Tweet`]
+            A list of `Tweet` results.
+
+        Examples
+        --------
+        >>> mentions = await client.get_user_mentions('5mknc5', search_count=30)
+        >>> for mention in mentions:
+        ...     print(mention)
+        <Tweet id="...">
+        <Tweet id="...">
+        ...
+        ...
+
+        """
         result = await self.search_tweet(f"@{handle}", "Latest", count=search_count)
         mentions = []
         for tweet in result:


### PR DESCRIPTION
Added get_user_mentions functionality (X API v2).

Example usage:

```python
mentions = await client.get_user_mentions('5mknc5', search_count=30)
for mention in mentions:
        print(mention)
```

Output:
```
<Tweet id="...">
<Tweet id="...">
...
...
```