### PR TITLE
Prevent KeyError when accessing content.value for next cursor

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -1632,7 +1632,7 @@ class Client:
 
         if entries[-1]['entryId'].startswith('cursor'):
             # if has more replies
-            reply_next_cursor = entries[-1]['content']['itemContent']['value']
+            reply_next_cursor = entries[-1]['content']['value']
             _fetch_more_replies = partial(self._get_more_replies,
                                           tweet_id, reply_next_cursor)
         else:


### PR DESCRIPTION
Possible fix for a bug where client.get_tweet_by_id() throws a KeyError when the tweet has replies.

## Summary by Sourcery

Bug Fixes:
- Adjust reply_next_cursor lookup to use content.value instead of content.itemContent.value to avoid KeyError for tweets with replies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where additional replies in long tweet threads sometimes failed to load.
  * Corrected pagination handling to ensure subsequent pages of replies load consistently.
  * Improves reliability when expanding and navigating through reply chains.
  * No changes to the public API or user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->