### PR TITLE
Add notifications field to the User class

### DIFF
--- a/twikit/user.py
+++ b/twikit/user.py
@@ -84,11 +84,14 @@ class User:
         The type of profile interstitial.
     withheld_in_countries : list[:class:`str`]
         Countries where the user's content is withheld.
+    notifications : :class:`bool`
+        Indicates if notifications were enabled for this user.
     """
 
     def __init__(self, client: Client, data: dict) -> None:
         self._client = client
         legacy = data['legacy']
+        self._legacy: dict = legacy
 
         self.id: str = data['rest_id']
         self.created_at: str = legacy['created_at']
@@ -123,6 +126,7 @@ class User:
         self.translator_type: str = legacy['translator_type']
         self.withheld_in_countries: list[str] = legacy['withheld_in_countries']
         self.protected: bool = legacy.get('protected', False)
+        self.notifications: bool = legacy.get('notifications', False)
 
     @property
     def created_at_datetime(self) -> datetime:


### PR DESCRIPTION
ditto.

## Summary by Sourcery

Add a notifications boolean field to the User class and retain legacy data for future use

New Features:
- Introduce a notifications attribute on User to reflect legacy notification settings

Enhancements:
- Preserve the entire legacy data payload in a new _legacy attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User objects now include a notifications boolean attribute indicating whether notifications are enabled for the user. When legacy data is unavailable, it defaults to False.
* **Documentation**
  * Updated the User class documentation to describe the new notifications attribute, including its purpose and default behavior for improved discoverability and clarity for developers using the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->