### PR TITLE
Feat/adding conversation ids timeline

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -2008,6 +2008,15 @@ class Client:
         results = []
 
         for item in items:
+            if 'home-conversation' in item['entryId']:
+              tweets = item['content']['items']
+              tweet = tweet_from_data(self, tweets[0])
+              for other_tweet in tweets[1:]:
+                tweet.replies.append(tweet_from_data(self, other_tweet))
+              tweet.conversation_ids = item['content']['metadata']['conversationMetadata']['allTweetIds']
+              results.append(tweet)
+              continue
+
             if 'itemContent' not in item['content']:
                 continue
             tweet = tweet_from_data(self, item)
@@ -2068,6 +2077,15 @@ class Client:
         results = []
 
         for item in items:
+            if 'home-conversation' in item['entryId']:
+                tweets = item['content']['items']
+                tweet = tweet_from_data(self, tweets[0])
+                for other_tweet in tweets[1:]:
+                  tweet.replies.append(tweet_from_data(self, other_tweet))
+                tweet.conversation_ids = item['content']['metadata']['conversationMetadata']['allTweetIds']
+                results.append(tweet)
+                continue
+              
             if 'itemContent' not in item['content']:
                 continue
             tweet = tweet_from_data(self, item)

--- a/twikit/tweet.py
+++ b/twikit/tweet.py
@@ -104,6 +104,7 @@ class Tweet:
         self.user = user
 
         self.replies: Result[Tweet] | None = None
+        self.conversation_ids: list[str] | None = None
         self.reply_to: list[Tweet] | None = None
         self.related_tweets: list[Tweet] | None = None
         self.thread: list[Tweet] | None = None
@@ -131,6 +132,10 @@ class Tweet:
     @property
     def is_quote_status(self) -> bool:
         return self._legacy['is_quote_status']
+
+    @property
+    def conversation_ids(self) -> list[str] | None:
+        return self._data['conversation_ids']
 
     @property
     def possibly_sensitive(self) -> bool:


### PR DESCRIPTION
## Summary by Sourcery

Add support for extracting and exposing conversation IDs on Tweet objects for conversation threads

New Features:
- Add conversation_ids attribute and property to Tweet to store all tweet IDs in a conversation thread

Enhancements:
- Populate conversation_ids in get_user_tweets, get_timeline, and get_latest_timeline by extracting conversationMetadata.allTweetIds for profile- and home-conversation entries