### PR TITLE
add profile spotlights query

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -46,7 +46,7 @@ from ..streaming import Payload, StreamingSession, _payload_from_data
 from ..trend import Location, PlaceTrend, PlaceTrends, Trend
 from ..tweet import CommunityNote, Poll, ScheduledTweet, Tweet, tweet_from_data
 from ..ui_metrics import solve_ui_metrics
-from ..user import User
+from ..user import User, ProfileSpotlights
 from ..utils import (
     Flow,
     Result,
@@ -4322,3 +4322,8 @@ class Client:
     async def _get_user_state(self) -> Literal['normal', 'bounced', 'suspended']:
         response, _ = await self.v11.user_state()
         return response['userState']
+
+    async def get_profile_spotlights(self, display_name: str) -> ProfileSpotlights:
+        response, _ = await self.gql.profile_spotlights(display_name)
+        result = find_dict(response, 'result', find_one=True)[0]
+        return ProfileSpotlights(result)

--- a/twikit/client/gql.py
+++ b/twikit/client/gql.py
@@ -99,6 +99,7 @@ class Endpoint:
     MODERATORS_SLICE_TIMELINE_QUERY = url('9KI_r8e-tgp3--N5SZYVjg/moderatorsSliceTimeline_Query')
     COMMUNITY_TWEET_SEARCH_MODULE_QUERY = url('5341rmzzvdjqfmPKfoHUBw/CommunityTweetSearchModuleQuery')
     TWEET_RESULTS_BY_REST_IDS = url('PTN9HhBAlpoCTHfspDgqLA/TweetResultsByRestIds')
+    PROFILE_SPOTLIGHTS = url('1sAf0uU4-B2ZLJGUX5O7LQ/ProfileSpotlightsQuery')
 
 
 class GQLClient:
@@ -681,6 +682,10 @@ class GQLClient:
             'withCommunity': True
         }
         return await self.gql_get(Endpoint.TWEET_RESULTS_BY_REST_IDS, variables, TWEET_RESULTS_BY_REST_IDS_FEATURES)
+
+    async def profile_spotlights(self, screen_name):
+        variables = {'screen_name': screen_name}
+        return await self.gql_get(Endpoint.PROFILE_SPOTLIGHTS, variables)
 
     ####################
     # For guest client

--- a/twikit/user.py
+++ b/twikit/user.py
@@ -14,6 +14,24 @@ if TYPE_CHECKING:
     from .utils import Result
 
 
+class ProfileSpotlights:
+    def __init__(self, data: dict):
+        self._data = data
+        relationship_perspectives = data.get('relationship_perspectives', {})
+        privacy = data.get('privacy', {})
+        core = data.get('core', {})
+
+        self.protected = privacy.get('protected', {})
+        self.blocking = relationship_perspectives.get('blocking', False)
+        self.blocked_by = relationship_perspectives.get('blocked_by', False)
+        self.following = relationship_perspectives.get('following', False)
+        self.followed_by = relationship_perspectives.get('followed_by', False)
+        self.is_verified_organisation = data.get('is_verified_organisation', False)
+        self.rest_id = data.get('rest_id', None)
+        self.name = core.get('name', None)
+        self.screen_name = core.get('screen_name', None)
+
+
 class User:
     """
     Attributes
@@ -506,6 +524,9 @@ class User:
         ...
         """
         return await self._client.get_user_highlights_tweets(self.id, count, cursor)
+
+    async def get_profile_spotlights(self) -> ProfileSpotlights:
+        return await self._client.get_profile_spotlights(self.screen_name)
 
     async def update(self) -> None:
         new = await self._client.get_user_by_id(self.id)


### PR DESCRIPTION
## Summary by Sourcery

Add support for fetching and modeling profile spotlights via a new GraphQL query.

New Features:
- Introduce ProfileSpotlights class to encapsulate spotlight attributes
- Add GRAPHQL PROFILE_SPOTLIGHTS endpoint and GQLClient.profile_spotlights method
- Implement Client.get_profile_spotlights and User.get_profile_spotlights to expose the query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to retrieve profile spotlight information for any account by screen/display name.
  - Available from both the main client and user instances for convenient access.
  - Returns key details such as privacy status, follow/block relationships, verification status, and basic profile identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->