### PR TITLE
fix: update ondemand.s regex for new webpack chunk format

### DIFF
--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -13,9 +13,9 @@ from .rotation import convert_rotation_to_matrix
 from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 
 ON_DEMAND_FILE_REGEX = re.compile(
-    r"""['|\"]{1}ondemand\.s['|\"]{1}:\s*['|\"]{1}([\w]*)['|\"]{1}""", flags=(re.VERBOSE | re.MULTILINE))
-INDICES_REGEX = re.compile(
-    r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
+    r',(\d+):["\']ondemand\.s["\']', flags=(re.VERBOSE | re.MULTILINE))
+ON_DEMAND_HASH_PATTERN = r',{}:"([0-9a-f]+)"'
+INDICES_REGEX = re.compile(r'\[(\d+)\],\s*16')
 
 
 class ClientTransaction:
@@ -42,14 +42,17 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
-        if on_demand_file:
-            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"
-            on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
-            key_byte_indices_match = INDICES_REGEX.finditer(
-                str(on_demand_file_response.text))
-            for item in key_byte_indices_match:
-                key_byte_indices.append(item.group(2))
+        on_demand_match = ON_DEMAND_FILE_REGEX.search(str(response))
+        if on_demand_match:
+            chunk_index = on_demand_match.group(1)
+            hash_match = re.search(
+                ON_DEMAND_HASH_PATTERN.format(chunk_index), str(response))
+            if hash_match:
+                file_hash = hash_match.group(1)
+                on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{file_hash}a.js"
+                on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
+                for item in INDICES_REGEX.finditer(on_demand_file_response.text):
+                    key_byte_indices.append(item.group(1))
         if not key_byte_indices:
             raise Exception("Couldn't get KEY_BYTE indices")
         key_byte_indices = list(map(int, key_byte_indices))


### PR DESCRIPTION
## Problem

X changed how the `ondemand.s` JS bundle is referenced in their HTML (around March 18, 2026). The old webpack format embedded the hash directly next to the chunk name:

```js
'ondemand.s': 'abc123'
```

The new format uses a numeric chunk index that maps to the hash in a separate JavaScript object:

```js
,1234:"ondemand.s"  ...  ,1234:"abc123"
```

This causes `ON_DEMAND_FILE_REGEX` to fail, which means `get_indices` can't find the `KEY_BYTE` indices, raising `Couldn't get KEY_BYTE indices` for every API call.

## Fix

Three changes in `transaction.py`:

1. **`ON_DEMAND_FILE_REGEX`** — now captures the numeric chunk index instead of the hash directly
2. **`ON_DEMAND_HASH_PATTERN`** (new) — uses the chunk index to find the actual hash in a second pass
3. **`INDICES_REGEX`** — updated to match the new JS format (`[N], 16` instead of `(a[N], 16)`)
4. **`get_indices`** — two-step lookup: find chunk index → resolve to file hash → fetch JS → extract indices

## Testing

Tested and confirmed working as of 2026-03-26 in a tweet scheduling app that uses `set_cookies` + `create_tweet` + `upload_media`.

Fixes #408
Fixes #409

## Summary by Sourcery

Update X client transaction logic to handle the new webpack chunk format for the ondemand.s bundle so KEY_BYTE indices can be resolved again.

Bug Fixes:
- Adjust ondemand.s bundle detection to use the numeric chunk index and resolve the corresponding file hash from the updated HTML/JS format.
- Update KEY_BYTE indices extraction to match the new JavaScript pattern emitted by the ondemand.s chunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transaction parsing logic with simplified and more efficient pattern matching for on-demand asset resolution, ensuring more reliable extraction of required indices during the transaction processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->