### PR TITLE
fix: update search_timeline to use POST to resolve 404 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *.json
 /*.py
 /node_modules
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+env/

--- a/twikit/client/gql.py
+++ b/twikit/client/gql.py
@@ -156,7 +156,7 @@ class GQLClient:
         }
         if cursor is not None:
             variables['cursor'] = cursor
-        return await self.gql_get(Endpoint.SEARCH_TIMELINE, variables, FEATURES)
+        return await self.gql_post(Endpoint.SEARCH_TIMELINE, variables, FEATURES)
 
     async def similar_posts(self, tweet_id: str):
         variables = {'tweet_id': tweet_id}

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -44,6 +44,9 @@ class ClientTransaction:
             home_page_response) or self.home_page_response
         on_demand_file_index = ON_DEMAND_FILE_REGEX.search(str(response)).group(1)
         regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index))
+        #on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
+        #if on_demand_file:
+           #on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"  
         filename = regex.search(str(response)).group(1)
         on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{filename}a.js"
         on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -12,8 +12,8 @@ from .interpolate import interpolate
 from .rotation import convert_rotation_to_matrix
 from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 
-ON_DEMAND_FILE_REGEX = re.compile(
-    r"""['|\"]{1}ondemand\.s['|\"]{1}:\s*['|\"]{1}([\w]*)['|\"]{1}""", flags=(re.VERBOSE | re.MULTILINE))
+ON_DEMAND_FILE_REGEX: re.Pattern = re.compile(r""",(\d+):["']ondemand\.s["']""", flags=(re.VERBOSE | re.MULTILINE))
+ON_DEMAND_HASH_PATTERN: str = r',{}:\"([0-9a-f]+)\"'
 INDICES_REGEX = re.compile(
     r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
 
@@ -42,14 +42,15 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
-        if on_demand_file:
-            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"
-            on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
-            key_byte_indices_match = INDICES_REGEX.finditer(
-                str(on_demand_file_response.text))
-            for item in key_byte_indices_match:
-                key_byte_indices.append(item.group(2))
+        on_demand_file_index = ON_DEMAND_FILE_REGEX.search(str(response)).group(1)
+        regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index))
+        filename = regex.search(str(response)).group(1)
+        on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{filename}a.js"
+        on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
+        key_byte_indices_match = INDICES_REGEX.finditer(
+            str(on_demand_file_response.text))
+        for item in key_byte_indices_match:
+            key_byte_indices.append(item.group(2))
         if not key_byte_indices:
             raise Exception("Couldn't get KEY_BYTE indices")
         key_byte_indices = list(map(int, key_byte_indices))

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -43,11 +43,12 @@ class ClientTransaction:
         response = self.validate_response(
             home_page_response) or self.home_page_response
         on_demand_file_index = ON_DEMAND_FILE_REGEX.search(str(response)).group(1)
-        regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index))
-        #on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
-        #if on_demand_file:
-           #on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"  
+        if not on_demand_file_index:
+            raise Exception("Failed to match ON_DEMAND_FILE_REGEX in the home page response") 
+        regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index)) 
         filename = regex.search(str(response)).group(1)
+        if not filename:
+            raise Exception(f"Failed to match the hash pattern for on_demand_file index {on_demand_file_index}")
         on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{filename}a.js"
         on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
         key_byte_indices_match = INDICES_REGEX.finditer(

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -42,13 +42,15 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file_index = ON_DEMAND_FILE_REGEX.search(str(response)).group(1)
-        if not on_demand_file_index:
-            raise Exception("Failed to match ON_DEMAND_FILE_REGEX in the home page response") 
+        on_demand_file_match = ON_DEMAND_FILE_REGEX.search(str(response))
+        if not on_demand_file_match:
+            raise Exception("Failed to match ON_DEMAND_FILE_REGEX in the home page response")
+        on_demand_file_index = on_demand_file_match.group(1)
         regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index)) 
-        filename = regex.search(str(response)).group(1)
-        if not filename:
-            raise Exception(f"Failed to match the hash pattern for on_demand_file index {on_demand_file_index}")
+        filename_match = regex.search(str(response))
+        if not filename_match:
+            raise Exception(f"Failed to match the hash pattern for on_demand_file index {on_demand_file_index}") 
+        filename = filename_match.group(1)
         on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{filename}a.js"
         on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
         key_byte_indices_match = INDICES_REGEX.finditer(


### PR DESCRIPTION
SsearchTimeline GET requests are being blocked, changed to a POST request so that the query variables are in the request body now.

In gql.py, I changed the gql_get on line 159 to gql_post and now the ability to search for tweets is operational again.

## Summary by Sourcery

Update Twitter client internals to restore search functionality and align ondemand script parsing with current response format.

Bug Fixes:
- Switch search timeline GraphQL requests from GET to POST so search works when GET is blocked.
- Update ondemand script URL extraction to correctly resolve the current ondemand JavaScript filename and indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded development environment ignore patterns to reduce noise from Python and virtual environment artifacts.

* **Refactor**
  * Switched timeline network requests to a more robust method for improved reliability.
  * Hardened on-demand asset discovery and parsing to fail more deterministically and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->