### PR TITLE
fix: support new webpack chunk format for ondemand.s lookup

### DIFF
--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -14,6 +14,8 @@ from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 
 ON_DEMAND_FILE_REGEX = re.compile(
     r"""['|\"]{1}ondemand\.s['|\"]{1}:\s*['|\"]{1}([\w]*)['|\"]{1}""", flags=(re.VERBOSE | re.MULTILINE))
+# New webpack format: chunk ID maps to name, separate hash map
+CHUNK_NAME_REGEX = re.compile(r'(\d+):"ondemand\.s"')
 INDICES_REGEX = re.compile(
     r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
 
@@ -42,9 +44,30 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
+        response_str = str(response)
+
+        # Try old format first: 'ondemand.s': 'hash'
+        on_demand_file = ON_DEMAND_FILE_REGEX.search(response_str)
         if on_demand_file:
-            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"
+            file_hash = on_demand_file.group(1)
+        else:
+            # New webpack format: chunk_id:"ondemand.s" with hash in a separate map
+            chunk_id_match = CHUNK_NAME_REGEX.search(response_str)
+            if chunk_id_match:
+                chunk_id = chunk_id_match.group(1)
+                hash_pattern = re.compile(rf'{chunk_id}:"([\w]+)"')
+                all_matches = list(hash_pattern.finditer(response_str))
+                file_hash = None
+                for m in all_matches:
+                    val = m.group(1)
+                    if val != 'ondemand' and len(val) <= 12:
+                        file_hash = val
+                        break
+            else:
+                file_hash = None
+
+        if file_hash:
+            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{file_hash}a.js"
             on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
             key_byte_indices_match = INDICES_REGEX.finditer(
                 str(on_demand_file_response.text))


### PR DESCRIPTION
## Problem

Twitter changed the structure of `x.com`'s HTML, breaking the `ClientTransaction.get_indices()` method for all users.

The old format was:
```
'ondemand.s': 'abc123'
```

The current format uses a webpack chunk map split across two objects:
```js
// name map
{20113:"ondemand.s", ...}
// hash map (separate)
{20113:"2c5bb94", ...}
```

The existing `ON_DEMAND_FILE_REGEX` no longer matches, causing this error on **every single API call**:
```
Exception: Couldn't get KEY_BYTE indices
```

## Fix

- Added `CHUNK_NAME_REGEX` to extract the chunk ID from the name map
- Falls back to resolving the hash from the separate hash map using that chunk ID
- Old format still works (tried first), so this is fully backwards compatible

## Testing

Verified locally against live `x.com` — list scraping, tweet fetching, and search all work correctly after the fix.

## Summary by Sourcery

Bug Fixes:
- Fix failure to locate ondemand.s script hash after Twitter changed the webpack chunking scheme, restoring successful key byte index extraction for API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of updated asset manifests so on-demand resources load reliably across old and new backend formats, reducing failed asset fetches and page load errors for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->