### PR TITLE
Fix SearchTimeline 404 + defensive parsing fixes

### DIFF
--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 import filetype
 import pyotp
-from httpx import AsyncClient, AsyncHTTPTransport, Response
+from httpx import AsyncClient, AsyncHTTPTransport, HTTPError, Response
 from httpx._utils import URLPattern
 
 from .._captcha import Capsolver
@@ -4348,11 +4348,16 @@ class Client:
         # branch and recurse until Python raises `RecursionError`. That
         # masks the real 429 with an unrelated crash.
         #
-        # Trap any exception from the nested call and fall back to
-        # 'normal'. The original 429 is still raised by the outer
-        # `request()`; we just avoid turning it into a recursive crash.
+        # Trap only the failure modes that would otherwise feed the
+        # recursion loop, or an unrelated transport failure from the
+        # nested GET. The outer `request()` still raises
+        # `TooManyRequests` for the original 429 — callers see the
+        # correct exception, we just avoid the recursive crash.
+        #
+        # Anything else (unexpected JSON shape, programming errors,
+        # auth failures) should keep propagating so real bugs surface.
         try:
             response, _ = await self.v11.user_state()
             return response['userState']
-        except Exception:
+        except (TooManyRequests, RecursionError, HTTPError):
             return 'normal'

--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -126,6 +126,7 @@ class Client:
         url: str,
         auto_unlock: bool = True,
         raise_exception: bool = True,
+        check_user_state: bool = True,
         **kwargs
     ) -> tuple[dict | Any, Response]:
         ':meta private:'
@@ -193,7 +194,11 @@ class Client:
             elif status_code == 408:
                 raise RequestTimeout(message, headers=response.headers)
             elif status_code == 429:
-                if await self._get_user_state() == 'suspended':
+                # `check_user_state=False` when called recursively from
+                # `_get_user_state()` itself — otherwise a 429 on the nested
+                # user_state GET would re-enter this branch, call
+                # `_get_user_state()` again, and loop until RecursionError.
+                if check_user_state and await self._get_user_state() == 'suspended':
                     raise AccountSuspended(message, headers=response.headers)
                 raise TooManyRequests(message, headers=response.headers)
             elif 500 <= status_code < 600:
@@ -4348,16 +4353,19 @@ class Client:
         # branch and recurse until Python raises `RecursionError`. That
         # masks the real 429 with an unrelated crash.
         #
-        # Trap only the failure modes that would otherwise feed the
-        # recursion loop, or an unrelated transport failure from the
-        # nested GET. The outer `request()` still raises
-        # `TooManyRequests` for the original 429 — callers see the
-        # correct exception, we just avoid the recursive crash.
+        # Pass `check_user_state=False` to the nested request so that if
+        # this user_state GET also 429s, `request()` raises `TooManyRequests`
+        # directly instead of re-entering this branch. That eliminates the
+        # recursion at the source — not just after N levels deep — so we
+        # don't burn through HTTP calls climbing back up the stack.
         #
-        # Anything else (unexpected JSON shape, programming errors,
-        # auth failures) should keep propagating so real bugs surface.
+        # We still trap the remaining failure modes: the expected
+        # `TooManyRequests` (now raised on the first retry, not at the
+        # recursion limit), and any transport-level `HTTPError`. Anything
+        # else (unexpected JSON, auth issues, programming errors) keeps
+        # propagating so real bugs surface.
         try:
-            response, _ = await self.v11.user_state()
+            response, _ = await self.v11.user_state(check_user_state=False)
             return response['userState']
-        except (TooManyRequests, RecursionError, HTTPError):
+        except (TooManyRequests, HTTPError):
             return 'normal'

--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -1522,12 +1522,22 @@ class Client:
             if tweet is not None:
                 results.append(tweet)
 
-        if entries[-1]['entryId'].startswith('cursor'):
-            next_cursor = entries[-1]['content']['itemContent']['value']
-            _fetch_next_result = partial(self._get_more_replies, tweet_id, next_cursor)
-        else:
-            next_cursor = None
-            _fetch_next_result = None
+        # Mirror the two-shape handling added to `get_tweet_by_id`: without it
+        # the first `await tweet.replies.next()` call would re-introduce the
+        # KeyError that the parent fix eliminated (X serves the trailing cursor
+        # as either `content.itemContent.value` or flat `content.value`).
+        next_cursor = None
+        _fetch_next_result = None
+        if entries and entries[-1].get('entryId', '').startswith('cursor'):
+            content = entries[-1].get('content') or {}
+            item_content = content.get('itemContent')
+            if isinstance(item_content, dict) and 'value' in item_content:
+                next_cursor = item_content['value']
+            elif 'value' in content:
+                next_cursor = content['value']
+            if next_cursor is not None:
+                _fetch_next_result = partial(
+                    self._get_more_replies, tweet_id, next_cursor)
 
         return Result(
             results,
@@ -1632,7 +1642,7 @@ class Client:
 
         reply_next_cursor = None
         _fetch_more_replies = None
-        if entries and entries[-1]['entryId'].startswith('cursor'):
+        if entries and entries[-1].get('entryId', '').startswith('cursor'):
             # X has two shapes for the trailing cursor entry: the legacy
             # `content.itemContent.value` and a newer, flatter `content.value`
             # (TimelineTimelineCursor without an itemContent wrapper). Reading

--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -4330,5 +4330,19 @@ class Client:
         return _payload_from_data(response)
 
     async def _get_user_state(self) -> Literal['normal', 'bounced', 'suspended']:
-        response, _ = await self.v11.user_state()
-        return response['userState']
+        # `request()` calls this method whenever it receives a 429, to
+        # decide between `TooManyRequests` and `AccountSuspended`. But the
+        # call itself goes through `request()` as well, so if the
+        # user_state endpoint is ALSO rate-limited (very common — X rate
+        # limits the whole account, not per-endpoint), we re-enter this
+        # branch and recurse until Python raises `RecursionError`. That
+        # masks the real 429 with an unrelated crash.
+        #
+        # Trap any exception from the nested call and fall back to
+        # 'normal'. The original 429 is still raised by the outer
+        # `request()`; we just avoid turning it into a recursive crash.
+        try:
+            response, _ = await self.v11.user_state()
+            return response['userState']
+        except Exception:
+            return 'normal'

--- a/twikit/client/client.py
+++ b/twikit/client/client.py
@@ -1630,14 +1630,24 @@ class Client:
                     if display_type and display_type[0] == 'SelfThread':
                         tweet.thread = [tweet_object, *replies]
 
-        if entries[-1]['entryId'].startswith('cursor'):
-            # if has more replies
-            reply_next_cursor = entries[-1]['content']['itemContent']['value']
-            _fetch_more_replies = partial(self._get_more_replies,
-                                          tweet_id, reply_next_cursor)
-        else:
-            reply_next_cursor = None
-            _fetch_more_replies = None
+        reply_next_cursor = None
+        _fetch_more_replies = None
+        if entries and entries[-1]['entryId'].startswith('cursor'):
+            # X has two shapes for the trailing cursor entry: the legacy
+            # `content.itemContent.value` and a newer, flatter `content.value`
+            # (TimelineTimelineCursor without an itemContent wrapper). Reading
+            # the old path unconditionally raises KeyError: 'itemContent' for
+            # any tweet served with the new shape, which breaks the whole
+            # `get_tweet_by_id` call — not just pagination of further replies.
+            content = entries[-1].get('content') or {}
+            item_content = content.get('itemContent')
+            if isinstance(item_content, dict) and 'value' in item_content:
+                reply_next_cursor = item_content['value']
+            elif 'value' in content:
+                reply_next_cursor = content['value']
+            if reply_next_cursor is not None:
+                _fetch_more_replies = partial(self._get_more_replies,
+                                              tweet_id, reply_next_cursor)
 
         tweet.replies = Result(
             replies_list,

--- a/twikit/client/gql.py
+++ b/twikit/client/gql.py
@@ -11,6 +11,7 @@ from ..constants import (
     JOIN_COMMUNITY_FEATURES,
     LIST_FEATURES,
     NOTE_TWEET_FEATURES,
+    SEARCH_TIMELINE_FEATURES,
     SIMILAR_POSTS_FEATURES,
     TWEET_RESULT_BY_REST_ID_FEATURES,
     TWEET_RESULTS_BY_REST_IDS_FEATURES,
@@ -31,7 +32,7 @@ class Endpoint:
     def url(path):
         return f'https://{DOMAIN}/i/api/graphql/{path}'
 
-    SEARCH_TIMELINE = url('flaR-PUMshxFWZWPNpq4zA/SearchTimeline')
+    SEARCH_TIMELINE = url('R0u1RWRf748KzyGBXvOYRA/SearchTimeline')
     SIMILAR_POSTS = url('EToazR74i0rJyZYalfVEAQ/SimilarPosts')
     CREATE_NOTE_TWEET = url('iCUB42lIfXf9qPKctjE5rQ/CreateNoteTweet')
     CREATE_TWEET = url('SiM_cAu83R0wnrpmKQQSEw/CreateTweet')
@@ -152,11 +153,14 @@ class GQLClient:
             'rawQuery': query,
             'count': count,
             'querySource': 'typed_query',
-            'product': product
+            'product': product,
+            'withGrokTranslatedBio': True
         }
         if cursor is not None:
             variables['cursor'] = cursor
-        return await self.gql_get(Endpoint.SEARCH_TIMELINE, variables, FEATURES)
+        return await self.gql_get(
+            Endpoint.SEARCH_TIMELINE, variables, SEARCH_TIMELINE_FEATURES
+        )
 
     async def similar_posts(self, tweet_id: str):
         variables = {'tweet_id': tweet_id}

--- a/twikit/client/v11.py
+++ b/twikit/client/v11.py
@@ -505,8 +505,14 @@ class V11Client:
             Endpoint.LIVE_PIPELINE_UPDATE_SUBSCRIPTIONS, data=data, headers=headers
         )
 
-    async def user_state(self):
+    async def user_state(self, **kwargs):
+        # `**kwargs` is forwarded to `base.get` → `base.request`. The 429
+        # recovery path in `Client.request` calls `_get_user_state()`, which
+        # ends up back here; we need to pass `check_user_state=False` down
+        # so that if this nested call also returns 429 we don't retry the
+        # recovery check and loop.
         return await self.base.get(
             Endpoint.USER_STATE,
-            headers=self.base._base_headers
+            headers=self.base._base_headers,
+            **kwargs
         )

--- a/twikit/constants.py
+++ b/twikit/constants.py
@@ -228,6 +228,46 @@ USER_HIGHLIGHTS_TWEETS_FEATURES = {
     'responsive_web_enhance_cards_enabled': False
 }
 
+SEARCH_TIMELINE_FEATURES = {
+    'rweb_video_screen_enabled': False,
+    'rweb_cashtags_enabled': True,
+    'profile_label_improvements_pcf_label_in_post_enabled': True,
+    'responsive_web_profile_redirect_enabled': False,
+    'rweb_tipjar_consumption_enabled': False,
+    'verified_phone_label_enabled': False,
+    'creator_subscriptions_tweet_preview_api_enabled': True,
+    'responsive_web_graphql_timeline_navigation_enabled': True,
+    'responsive_web_graphql_skip_user_profile_image_extensions_enabled': False,
+    'premium_content_api_read_enabled': False,
+    'communities_web_enable_tweet_community_results_fetch': True,
+    'c9s_tweet_anatomy_moderator_badge_enabled': True,
+    'responsive_web_grok_analyze_button_fetch_trends_enabled': False,
+    'responsive_web_grok_analyze_post_followups_enabled': True,
+    'responsive_web_jetfuel_frame': True,
+    'responsive_web_grok_share_attachment_enabled': True,
+    'responsive_web_grok_annotations_enabled': True,
+    'articles_preview_enabled': True,
+    'responsive_web_edit_tweet_api_enabled': True,
+    'graphql_is_translatable_rweb_tweet_is_translatable_enabled': True,
+    'view_counts_everywhere_api_enabled': True,
+    'longform_notetweets_consumption_enabled': True,
+    'responsive_web_twitter_article_tweet_consumption_enabled': True,
+    'content_disclosure_indicator_enabled': True,
+    'content_disclosure_ai_generated_indicator_enabled': True,
+    'responsive_web_grok_show_grok_translated_post': True,
+    'responsive_web_grok_analysis_button_from_backend': True,
+    'post_ctas_fetch_enabled': True,
+    'freedom_of_speech_not_reach_fetch_enabled': True,
+    'standardized_nudges_misinfo': True,
+    'tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled': True,
+    'longform_notetweets_rich_text_read_enabled': True,
+    'longform_notetweets_inline_media_enabled': False,
+    'responsive_web_grok_image_annotation_enabled': True,
+    'responsive_web_grok_imagine_annotation_enabled': True,
+    'responsive_web_grok_community_note_auto_translation_is_enabled': True,
+    'responsive_web_enhance_cards_enabled': False
+}
+
 TWEET_RESULTS_BY_REST_IDS_FEATURES = {
     'creator_subscriptions_tweet_preview_api_enabled': True,
     'premium_content_api_read_enabled': False,

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -17,9 +17,19 @@ from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 # the chunk id first, then the hash is listed against the same id
 # elsewhere on the page. Two-step lookup: find the id, then find the
 # hash that was shipped for that id.
+#
+# Leading boundary is `[,{]` (not just `,`) so we also match the entry
+# when `ondemand.s` happens to be the first key of the webpack chunk
+# map (`{123:"ondemand.s",...}`). Quote class accepts both single and
+# double quotes on both halves — X has shipped both styles depending
+# on the minifier run, and a mismatch caused the hash lookup to miss.
 ON_DEMAND_FILE_REGEX = re.compile(
-    r""",(\d+):["']ondemand\.s["']""", flags=(re.VERBOSE | re.MULTILINE))
-ON_DEMAND_HASH_PATTERN = r',{}:\"([0-9a-f]+)\"'
+    r"""[,{](\d+):["']ondemand\.s["']""", flags=(re.VERBOSE | re.MULTILINE))
+# `{{` / `}}` escape the literal braces so `str.format()` substitutes
+# only the `{chunk_id}` placeholder. Otherwise the `{` at the start of
+# the character class is parsed as an unnamed format field and raises
+# `ValueError: unexpected '{' in field name`.
+ON_DEMAND_HASH_PATTERN = r'[,{{]{chunk_id}:["\']([0-9a-f]+)["\']'
 INDICES_REGEX = re.compile(
     r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
 
@@ -60,7 +70,8 @@ class ClientTransaction:
             # "Couldn't get KEY_BYTE indices" on every init.
             chunk_id = on_demand_file.group(1)
             hash_match = re.search(
-                ON_DEMAND_HASH_PATTERN.format(chunk_id), response_text)
+                ON_DEMAND_HASH_PATTERN.format(chunk_id=chunk_id),
+                response_text)
             if hash_match:
                 on_demand_file_url = (
                     f"https://abs.twimg.com/responsive-web/client-web/"

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -72,17 +72,26 @@ class ClientTransaction:
             hash_match = re.search(
                 ON_DEMAND_HASH_PATTERN.format(chunk_id=chunk_id),
                 response_text)
-            if hash_match:
-                on_demand_file_url = (
-                    f"https://abs.twimg.com/responsive-web/client-web/"
-                    f"ondemand.s.{hash_match.group(1)}a.js"
+            if not hash_match:
+                # Distinct failure mode from "couldn't get indices": we found
+                # the `ondemand.s` label but the hash mapping for that chunk
+                # id isn't in the page. Surface this separately so diagnosis
+                # doesn't conflate "page layout changed" with "hash missing"
+                # (they need different fixes — regex vs. re-capture).
+                raise Exception(
+                    f"Couldn't find ondemand.s hash for chunk id {chunk_id!r} "
+                    f"(page layout may have changed)"
                 )
-                on_demand_file_response = await session.request(
-                    method="GET", url=on_demand_file_url, headers=headers)
-                key_byte_indices_match = INDICES_REGEX.finditer(
-                    str(on_demand_file_response.text))
-                for item in key_byte_indices_match:
-                    key_byte_indices.append(item.group(2))
+            on_demand_file_url = (
+                f"https://abs.twimg.com/responsive-web/client-web/"
+                f"ondemand.s.{hash_match.group(1)}a.js"
+            )
+            on_demand_file_response = await session.request(
+                method="GET", url=on_demand_file_url, headers=headers)
+            key_byte_indices_match = INDICES_REGEX.finditer(
+                str(on_demand_file_response.text))
+            for item in key_byte_indices_match:
+                key_byte_indices.append(item.group(2))
         if not key_byte_indices:
             raise Exception("Couldn't get KEY_BYTE indices")
         key_byte_indices = list(map(int, key_byte_indices))

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -12,8 +12,14 @@ from .interpolate import interpolate
 from .rotation import convert_rotation_to_matrix
 from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 
+# The ondemand.s hash is no longer placed directly next to the
+# "ondemand.s" label in the webpack bundle. The current layout emits
+# the chunk id first, then the hash is listed against the same id
+# elsewhere on the page. Two-step lookup: find the id, then find the
+# hash that was shipped for that id.
 ON_DEMAND_FILE_REGEX = re.compile(
-    r"""['|\"]{1}ondemand\.s['|\"]{1}:\s*['|\"]{1}([\w]*)['|\"]{1}""", flags=(re.VERBOSE | re.MULTILINE))
+    r""",(\d+):["']ondemand\.s["']""", flags=(re.VERBOSE | re.MULTILINE))
+ON_DEMAND_HASH_PATTERN = r',{}:\"([0-9a-f]+)\"'
 INDICES_REGEX = re.compile(
     r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
 
@@ -42,14 +48,30 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
+        response_text = str(response)
+        on_demand_file = ON_DEMAND_FILE_REGEX.search(response_text)
         if on_demand_file:
-            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"
-            on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
-            key_byte_indices_match = INDICES_REGEX.finditer(
-                str(on_demand_file_response.text))
-            for item in key_byte_indices_match:
-                key_byte_indices.append(item.group(2))
+            # `on_demand_file.group(1)` is the webpack chunk id (a number
+            # like "123"), not the file hash itself. Look up the hash shipped
+            # for that id via a second regex. Previously we concatenated
+            # the match with 'a.js' directly, which matched the old bundle
+            # layout where `"ondemand.s":"HASH"` appeared together — that
+            # layout no longer exists, so the old path raised
+            # "Couldn't get KEY_BYTE indices" on every init.
+            chunk_id = on_demand_file.group(1)
+            hash_match = re.search(
+                ON_DEMAND_HASH_PATTERN.format(chunk_id), response_text)
+            if hash_match:
+                on_demand_file_url = (
+                    f"https://abs.twimg.com/responsive-web/client-web/"
+                    f"ondemand.s.{hash_match.group(1)}a.js"
+                )
+                on_demand_file_response = await session.request(
+                    method="GET", url=on_demand_file_url, headers=headers)
+                key_byte_indices_match = INDICES_REGEX.finditer(
+                    str(on_demand_file_response.text))
+                for item in key_byte_indices_match:
+                    key_byte_indices.append(item.group(2))
         if not key_byte_indices:
             raise Exception("Couldn't get KEY_BYTE indices")
         key_byte_indices = list(map(int, key_byte_indices))


### PR DESCRIPTION
## Summary

Four independent fixes that together restore `client.search_tweet()` and harden `get_tweet_by_id()` against schema drift on live x.com. Each commit is self-contained and can be reviewed / reverted independently.

1. **`Refresh SearchTimeline queryId/features/variables`** — X rotated the SearchTimeline GraphQL endpoint. Old doc_id (`flaR-PUMshxFWZWPNpq4zA`) now 404s, and X also expanded the accepted feature set and added a new `withGrokTranslatedBio` variable. Without all three in sync the endpoint returns 404 wholesale (not a partial shape), so `search_tweet()` has been completely non-functional on the current x.com. Adds a dedicated `SEARCH_TIMELINE_FEATURES` constant instead of extending the global `FEATURES` — avoids side effects on every other endpoint.

2. **`Defensively parse trailing cursor in get_tweet_by_id`** — X serves two shapes for the trailing cursor entry in TweetDetail: legacy `content.itemContent.value` and the newer flatter `content.value`. The current code reads the legacy path unconditionally and raises `KeyError: 'itemContent'` for any tweet served with the new shape — which aborts the whole `get_tweet_by_id()` call before `tweet.replies` is populated, even though the reply entries themselves were parsed fine. Read both shapes; fall back to `_fetch_more_replies=None` when neither is present (pagination of *further* replies is the only thing actually affected).

3. **`Guard against recursion in _get_user_state on rate-limit`** — `request()` calls `_get_user_state()` on 429 to distinguish `TooManyRequests` from `AccountSuspended`. But that call routes back through `request()`, and X rate-limits the account (not per-endpoint), so the nested call also 429s and we recurse until Python raises `RecursionError`. The real 429 is thus masked by an unrelated crash. Trap exceptions from the nested `v11.user_state()` call and fall back to `'normal'`; the outer `request()` still raises `TooManyRequests` correctly.

4. **`Update ondemand.s hash extraction for current webpack bundle`** — `ClientTransaction.init()` fails with `Couldn't get KEY_BYTE indices` on every run, causing the generator to fall back to a dummy `X-Client-Transaction-Id`. The dummy is accepted by HomeTimeline/UserTweets but rejected with 404 by SearchTimeline (selective endpoint enforcement, nearly invisible from the traceback). Root cause is a webpack bundle layout change: `\"ondemand.s\":\"HASH\"` is no longer a contiguous pair; the chunk id and the hash are keyed separately. Two-step lookup mirrors the strategy from the `x-client-transaction-id` PyPI package. After this fix, combined with (1), real search queries come back with real results.

## Test plan

- [x] Manually verified (2)-fix on a live tweet that previously raised `KeyError('itemContent')` from `get_tweet_by_id()`; it now returns successfully with all replies parsed.
- [x] Manually verified (4)-fix by calling `ClientTransaction.init()` against live x.com — indices are extracted correctly and `generate_transaction_id()` returns a valid 94-char token.
- [x] Manually verified (1)+(4) together by running `client.search_tweet(\"streetwear\", \"Top\")`, `client.search_tweet(\"japanese fashion\", \"Top\")`, and four more queries — each returns populated results where previously every query returned HTTP 404.
- [x] (3) reproduced pre-fix by deliberately throttling an account and observing the `RecursionError`; post-fix the expected `TooManyRequests` is raised instead.

No new dependencies. No breaking API changes.

## Scope note

These are all defensive / data-plane fixes. No changes to public method signatures, no new features, no migrations.

## Summary by Sourcery

Restore search timeline functionality against current x.com schema and harden tweet retrieval and client transaction handling against recent platform changes.

Bug Fixes:
- Handle both legacy and new cursor shapes in get_tweet_by_id to avoid KeyError and preserve replies parsing when pagination metadata changes.
- Prevent recursive 429 handling in _get_user_state by treating failures of the nested user_state call as a normal state so TooManyRequests is raised correctly.
- Update ondemand.s hash detection to match the current webpack bundle structure so real X-Client-Transaction-Id values can be generated instead of failing with missing KEY_BYTE indices.
- Update SearchTimeline GraphQL endpoint, features set, and variables (including withGrokTranslatedBio) so search_timeline/search_tweet no longer return 404 responses.

Enhancements:
- Introduce a dedicated SEARCH_TIMELINE_FEATURES constant to scope search-specific feature flags without affecting other GraphQL endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reply pagination to handle multiple cursor formats and avoid broken fetches when entries are missing.
  * Enhanced rate-limit and user-state handling to return a normal state on certain errors and prevent recursive failures.
  * Fixed asset/index resolution for on-demand bundles to avoid missed resources.

* **New Features**
  * Added a dedicated feature configuration for the search timeline and updated its GraphQL request parameters (including bio translation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->