### PR TITLE
Add Xquik search client

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,22 @@
+"""Regression tests for the streaming event type union."""
+
+import unittest
+from typing import get_args
+
+from twikit.streaming import DMUpdateEvent, DMTypingEvent, StreamEventType
+
+
+class StreamEventTypeTest(unittest.TestCase):
+    """Verify that every parsed stream event belongs to the public union."""
+
+    def test_contains_each_direct_message_event_once(self):
+        """Keep direct-message update and typing events in the union."""
+
+        event_types = get_args(StreamEventType)
+
+        self.assertEqual(event_types.count(DMUpdateEvent), 1)
+        self.assertEqual(event_types.count(DMTypingEvent), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xquik.py
+++ b/tests/test_xquik.py
@@ -1,0 +1,252 @@
+"""Tests for the optional Xquik search client."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+import httpx
+from twikit import XquikSearchClient
+
+
+class FakeResponse:
+    """Minimal HTTP response double for search tests."""
+
+    def __init__(self, payload):
+        """Store the JSON payload returned by the double."""
+
+        self.payload = payload
+
+    def json(self):
+        """Return the configured JSON payload."""
+
+        return self.payload
+
+    def raise_for_status(self):
+        """Represent a successful response."""
+
+        return None
+
+
+class ErrorResponse(FakeResponse):
+    """HTTP response double that raises a server error."""
+
+    def __init__(self):
+        """Build a bound request and response for the HTTP error."""
+
+        request = httpx.Request("GET", "https://xquik.com/api/v1/x/tweets/search")
+        response = httpx.Response(500, request=request)
+        super().__init__({})
+        self.error = httpx.HTTPStatusError(
+            "Server error",
+            request=request,
+            response=response,
+        )
+
+    def raise_for_status(self):
+        """Raise the configured HTTP status error."""
+
+        raise self.error
+
+
+class FakeClient:
+    """HTTP client double that records requests and lifecycle state."""
+
+    def __init__(self, payload=None, response=None):
+        """Configure the payload or explicit response returned by the client."""
+
+        self.payload = payload
+        self.response = response
+        self.requests = []
+        self.closed = False
+
+    def get(self, url, headers, params):
+        """Record one GET request and return the configured response."""
+
+        self.requests.append({"url": url, "headers": headers, "params": params})
+        if self.response:
+            return self.response
+        return FakeResponse(self.payload)
+
+    def close(self):
+        """Record that the client was closed."""
+
+        self.closed = True
+
+
+class XquikSearchClientTest(unittest.TestCase):
+    """Verify search validation, mapping, errors, and client ownership."""
+
+    def test_requires_api_key(self):
+        """Reject construction when no explicit or environment key exists."""
+
+        original_api_key = os.environ.pop("XQUIK_API_KEY", None)
+        try:
+            with self.assertRaises(ValueError):
+                XquikSearchClient(api_key="", client=FakeClient({}))
+        finally:
+            if original_api_key is not None:
+                os.environ["XQUIK_API_KEY"] = original_api_key
+
+    def test_uses_env_api_key_when_not_passed(self):
+        """Use XQUIK_API_KEY when the constructor receives no key."""
+
+        original_api_key = os.environ.get("XQUIK_API_KEY")
+        try:
+            os.environ["XQUIK_API_KEY"] = "env-key"
+
+            client = XquikSearchClient(client=FakeClient({}))
+
+            self.assertEqual(client.api_key, "env-key")
+        finally:
+            if original_api_key is None:
+                os.environ.pop("XQUIK_API_KEY", None)
+            else:
+                os.environ["XQUIK_API_KEY"] = original_api_key
+
+    def test_search_maps_tweets_and_pagination(self):
+        """Map tweet fields and pagination while preserving request inputs."""
+
+        fake_client = FakeClient(
+            {
+                "tweets": [
+                    {
+                        "id": "123",
+                        "text": "hello",
+                        "createdAt": "2026-06-30T00:00:00.000Z",
+                        "likeCount": 4,
+                        "retweetCount": 3,
+                        "replyCount": 2,
+                        "quoteCount": 1,
+                        "author": {"username": "xquik", "name": "Xquik"},
+                    }
+                ],
+                "has_next_page": True,
+                "next_cursor": "cursor-1",
+            }
+        )
+
+        result = XquikSearchClient(api_key="test-key", client=fake_client).search(
+            "x data",
+            limit=5,
+            cursor="cursor-0",
+        )
+
+        self.assertEqual(len(result.tweets), 1)
+        self.assertEqual(result.tweets[0].id, "123")
+        self.assertEqual(result.tweets[0].author_username, "xquik")
+        self.assertEqual(result.tweets[0].favorite_count, 4)
+        self.assertTrue(result.has_next_page)
+        self.assertEqual(result.next_cursor, "cursor-1")
+        self.assertEqual(
+            fake_client.requests[0]["url"],
+            "https://xquik.com/api/v1/x/tweets/search",
+        )
+        self.assertEqual(fake_client.requests[0]["headers"]["x-api-key"], "test-key")
+        self.assertEqual(fake_client.requests[0]["params"]["q"], "x data")
+        self.assertEqual(fake_client.requests[0]["params"]["limit"], 5)
+        self.assertEqual(fake_client.requests[0]["params"]["cursor"], "cursor-0")
+        self.assertFalse(fake_client.closed)
+
+    def test_search_propagates_time_filters(self):
+        """Send documented time filters with the search request."""
+
+        fake_client = FakeClient({"tweets": []})
+
+        XquikSearchClient(api_key="test-key", client=fake_client).search(
+            "x data",
+            since_time="2026-06-29T00:00:00Z",
+            until_time="2026-06-30T00:00:00Z",
+        )
+
+        params = fake_client.requests[0]["params"]
+        self.assertEqual(params["sinceTime"], "2026-06-29T00:00:00Z")
+        self.assertEqual(params["untilTime"], "2026-06-30T00:00:00Z")
+
+    def test_search_validates_inputs(self):
+        """Reject malformed query, type, limit, and time values locally."""
+
+        client = XquikSearchClient(api_key="test-key", client=FakeClient({}))
+
+        with self.assertRaises(ValueError):
+            client.search("")
+        with self.assertRaises(ValueError):
+            client.search("x data", query_type="Recent")
+        with self.assertRaises(ValueError):
+            client.search("x data", limit=0)
+        with self.assertRaises(ValueError):
+            client.search("x data", since_time="not-a-date")
+
+    def test_search_handles_sparse_tweet_payloads(self):
+        """Normalize sparse tweets and skip non-object entries."""
+
+        fake_client = FakeClient(
+            {
+                "tweets": [
+                    {"id": "missing-author", "text": "no author"},
+                    {"id": "bad-author", "text": "bad author", "author": "xquik"},
+                    "not-a-tweet",
+                    {
+                        "id": "messy-counts",
+                        "text": "counts",
+                        "likeCount": " 4 ",
+                        "retweetCount": "+3",
+                        "replyCount": True,
+                        "quoteCount": "1,200",
+                    },
+                ],
+            }
+        )
+
+        result = XquikSearchClient(api_key="test-key", client=fake_client).search("x data")
+
+        self.assertEqual(len(result.tweets), 3)
+        tweets_by_id = {tweet.id: tweet for tweet in result.tweets}
+        self.assertIsNone(tweets_by_id["missing-author"].author_username)
+        self.assertIsNone(tweets_by_id["bad-author"].author_name)
+        self.assertEqual(tweets_by_id["messy-counts"].favorite_count, 4)
+        self.assertEqual(tweets_by_id["messy-counts"].retweet_count, 3)
+        self.assertEqual(tweets_by_id["messy-counts"].reply_count, 1)
+        self.assertEqual(tweets_by_id["messy-counts"].quote_count, 1200)
+
+    def test_search_rejects_non_object_response(self):
+        """Reject JSON roots that are not objects."""
+
+        client = XquikSearchClient(api_key="test-key", client=FakeClient([]))
+
+        with self.assertRaises(ValueError):
+            client.search("x data")
+
+    def test_search_propagates_http_errors(self):
+        """Propagate HTTP status errors from the transport."""
+
+        client = XquikSearchClient(
+            api_key="test-key",
+            client=FakeClient(response=ErrorResponse()),
+        )
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            client.search("x data")
+
+    def test_search_closes_owned_client(self):
+        """Close internally created clients after the request."""
+
+        owned_clients = []
+
+        class OwnedFakeClient(FakeClient):
+            """Track each client created by the search implementation."""
+
+            def __init__(self, *args, **kwargs):
+                """Create and register an internally owned client double."""
+
+                super().__init__({"tweets": []})
+                owned_clients.append(self)
+
+        with patch("twikit.xquik.httpx.Client", OwnedFakeClient):
+            XquikSearchClient(api_key="test-key").search("x data")
+
+        self.assertEqual(len(owned_clients), 1)
+        self.assertTrue(owned_clients[0].closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twikit/__init__.py
+++ b/twikit/__init__.py
@@ -29,3 +29,4 @@ from .notification import Notification
 from .trend import Trend
 from .tweet import CommunityNote, Poll, ScheduledTweet, Tweet
 from .user import User
+from .xquik import XquikSearchClient, XquikSearchResult, XquikTweet

--- a/twikit/streaming.py
+++ b/twikit/streaming.py
@@ -205,7 +205,7 @@ class DMTypingEvent(NamedTuple):
     user_id: str  #: The ID of the typing user.
 
 StreamEventType = (ConfigEvent | SubscriptionsEvent |
-                   TweetEngagementEvent | DMTypingEvent | DMTypingEvent)
+                   TweetEngagementEvent | DMUpdateEvent | DMTypingEvent)
 
 
 class Topic:

--- a/twikit/xquik.py
+++ b/twikit/xquik.py
@@ -1,0 +1,195 @@
+"""Optional Xquik client for authenticated public X search."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional
+
+import httpx
+
+VALID_QUERY_TYPES = {"Latest", "Top"}
+MAX_SEARCH_LIMIT = 200
+
+
+@dataclass(frozen=True)
+class XquikTweet:
+    """A normalized tweet returned by an Xquik search."""
+
+    id: str
+    text: str
+    created_at: Optional[str]
+    author_username: Optional[str]
+    author_name: Optional[str]
+    reply_count: int
+    retweet_count: int
+    quote_count: int
+    favorite_count: int
+    raw: Mapping[str, Any]
+
+    @classmethod
+    def from_api(cls, tweet: Mapping[str, Any]) -> "XquikTweet":
+        """Create a normalized tweet from an Xquik response object."""
+
+        author = tweet.get("author")
+        author_data = author if isinstance(author, Mapping) else {}
+        return cls(
+            id=str(tweet.get("id", "")),
+            text=str(tweet.get("text", "")),
+            created_at=_optional_string(tweet.get("createdAt")),
+            author_username=_optional_string(author_data.get("username")),
+            author_name=_optional_string(author_data.get("name")),
+            reply_count=_int_value(tweet.get("replyCount")),
+            retweet_count=_int_value(tweet.get("retweetCount")),
+            quote_count=_int_value(tweet.get("quoteCount")),
+            favorite_count=_int_value(tweet.get("likeCount")),
+            raw=tweet,
+        )
+
+
+@dataclass(frozen=True)
+class XquikSearchResult:
+    """A page of normalized tweets and its pagination metadata."""
+
+    tweets: List[XquikTweet]
+    has_next_page: bool
+    next_cursor: Optional[str]
+    raw: Mapping[str, Any]
+
+
+class XquikSearchClient:
+    """Search public X data through the documented Xquik REST endpoint."""
+
+    DEFAULT_BASE_URL = "https://xquik.com"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 10.0,
+        client: Optional[httpx.Client] = None,
+    ) -> None:
+        """Configure the search client and resolve its API key."""
+
+        self.api_key = api_key or os.environ.get("XQUIK_API_KEY")
+        if not self.api_key:
+            raise ValueError("Set api_key or XQUIK_API_KEY before searching with Xquik.")
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.client = client
+
+    def search(
+        self,
+        query: str,
+        query_type: str = "Latest",
+        limit: int = 20,
+        cursor: Optional[str] = None,
+        since_time: Optional[str] = None,
+        until_time: Optional[str] = None,
+    ) -> XquikSearchResult:
+        """Search tweets and return normalized results."""
+
+        self._validate_search(query, query_type, limit, since_time, until_time)
+        params: Dict[str, Any] = {
+            "q": query,
+            "queryType": query_type,
+            "limit": limit,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        if since_time:
+            params["sinceTime"] = since_time
+        if until_time:
+            params["untilTime"] = until_time
+
+        data = self._get_search(params)
+        raw_tweets = data.get("tweets", [])
+        tweets = [
+            XquikTweet.from_api(tweet)
+            for tweet in raw_tweets
+            if isinstance(tweet, Mapping)
+        ]
+        return XquikSearchResult(
+            tweets=tweets,
+            has_next_page=bool(data.get("has_next_page")),
+            next_cursor=_optional_string(data.get("next_cursor")),
+            raw=data,
+        )
+
+    def _get_search(self, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Execute one search request and validate its response shape."""
+
+        owned_client = self.client is None
+        client = self.client or httpx.Client(timeout=self.timeout)
+        try:
+            response = client.get(
+                f"{self.base_url}/api/v1/x/tweets/search",
+                headers={"x-api-key": self.api_key},
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, Mapping):
+                raise ValueError("Xquik search response must be a JSON object.")
+            return data
+        finally:
+            if owned_client:
+                client.close()
+
+    def _validate_search(
+        self,
+        query: str,
+        query_type: str,
+        limit: int,
+        since_time: Optional[str],
+        until_time: Optional[str],
+    ) -> None:
+        """Validate search parameters before sending a request."""
+
+        if not query:
+            raise ValueError("query is required.")
+        if query_type not in VALID_QUERY_TYPES:
+            allowed = ", ".join(sorted(VALID_QUERY_TYPES))
+            raise ValueError(f"query_type must be one of: {allowed}.")
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise ValueError("limit must be an integer.")
+        if not 1 <= limit <= MAX_SEARCH_LIMIT:
+            raise ValueError(f"limit must be between 1 and {MAX_SEARCH_LIMIT}.")
+        _validate_iso_time(since_time, "since_time")
+        _validate_iso_time(until_time, "until_time")
+
+
+def _optional_string(value: Any) -> Optional[str]:
+    """Convert a present value to text while preserving missing values."""
+
+    return str(value) if value is not None else None
+
+
+def _int_value(value: Any) -> int:
+    """Normalize integer-like response values without raising."""
+
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip().replace(",", ""))
+        except ValueError:
+            return 0
+    return 0
+
+
+def _validate_iso_time(value: Optional[str], name: str) -> None:
+    """Validate an optional ISO 8601 timestamp."""
+
+    if value is None:
+        return
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be an ISO 8601 string.")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO 8601 string.") from exc


### PR DESCRIPTION
## Summary

- Add an optional `XquikSearchClient` for public tweet search.
- Keep Twikit defaults unchanged and require an explicit API key or `XQUIK_API_KEY`.
- Map Xquik responses into typed result objects with pagination metadata.
- Validate queries, query types, limits, and ISO 8601 time filters before requests.
- Normalize sparse payloads and formatted counters safely.
- Export the client and result types from the package root.

## Independent Repository Fix

`StreamEventType` listed `DMTypingEvent` twice and omitted `DMUpdateEvent`, even though `_event_from_data` can return a `DMUpdateEvent`. The patch restores `DMUpdateEvent`, removes the duplicate union member, and adds regression coverage for both direct-message event types.

## Review Repairs

- Cover environment-based keys while isolating missing-key tests.
- Cover cursor and time-filter propagation.
- Cover missing authors, non-object tweets, formatted counters, HTTP errors, and invalid response shapes.
- Verify injected-client and owned-client lifecycle behavior.
- Document all 36 added production and test definitions.
- Resolve every Sourcery and CodeRabbit review thread.
- Rebuild the reviewed patch as 1 signed commit on current upstream.

## Validation

- Python 3.11: `python -m unittest discover -s tests -p 'test_*.py'` (10 tests passed)
- `python -m py_compile twikit/xquik.py twikit/streaming.py tests/test_xquik.py tests/test_streaming.py`
- AST docstring audit: 36/36 definitions documented
- `git diff --check`

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
