### PR TITLE
Fix KEY_BYTE indices parsing + guard optional legacy user fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@
 >   [@ryanstoic](https://github.com/ryanstoic), plus hardening so the hash
 >   lookup accepts both single- and double-quoted values (the original PR
 >   only handled double quotes).
-> - `User.description_urls` and `User.withheld_in_countries` (both the
->   authenticated and guest-mode `User` classes) now tolerate X omitting
->   those fields from the response, instead of raising `KeyError`.
+> - `User.description_urls`, `User.withheld_in_countries`, and
+>   `User.pinned_tweet_ids` (both the authenticated and guest-mode `User`
+>   classes) now tolerate X omitting those fields from the response,
+>   instead of raising `KeyError`. `pinned_tweet_ids_str` in particular is
+>   commonly missing for accounts that have never pinned a tweet
+>   (observed on several corporate/official accounts).
 >
 > **Install this fork directly:**
 > ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+> [!IMPORTANT]
+> ## This is an unofficial community patch fork
+> This fork exists because [d60/twikit](https://github.com/d60/twikit) broke
+> against X's current frontend (`Exception: Couldn't get KEY_BYTE indices`,
+> see [#408](https://github.com/d60/twikit/issues/408) /
+> [#409](https://github.com/d60/twikit/issues/409)) and, as of this writing,
+> no fix has been merged/released to PyPI.
+>
+> **What's fixed here, on top of the latest `d60/twikit` release:**
+> - `ondemand.s` webpack-chunk regex updated to match X's current bundle
+>   format, adapted from community PR
+>   [d60/twikit#411](https://github.com/d60/twikit/pull/411) by
+>   [@ryanstoic](https://github.com/ryanstoic), plus hardening so the hash
+>   lookup accepts both single- and double-quoted values (the original PR
+>   only handled double quotes).
+> - `User.description_urls` and `User.withheld_in_countries` (both the
+>   authenticated and guest-mode `User` classes) now tolerate X omitting
+>   those fields from the response, instead of raising `KeyError`.
+>
+> **Install this fork directly:**
+> ```
+> pip install git+https://github.com/leslienwu/twikit-patched.git@fix/ondemand-key-byte-indices-2026
+> ```
+>
+> This is a personal patch maintained on a best-effort basis, not a
+> long-term fork of the project — if/when these fixes (or better ones) land
+> upstream in `d60/twikit`, prefer that instead.
+
 > [!NOTE]
 > https://github.com/d60/twitter_login (under development)
 

--- a/twikit/guest/user.py
+++ b/twikit/guest/user.py
@@ -93,7 +93,7 @@ class User:
         self.url: str = legacy.get('url')
         self.location: str = legacy['location']
         self.description: str = legacy['description']
-        self.description_urls: list = legacy['entities']['description']['urls']
+        self.description_urls: list = legacy['entities'].get('description', {}).get('urls', [])
         self.urls: list = legacy['entities'].get('url', {}).get('urls')
         self.pinned_tweet_ids: list[str] = legacy['pinned_tweet_ids_str']
         self.is_blue_verified: bool = data['is_blue_verified']
@@ -112,7 +112,7 @@ class User:
         self.statuses_count: int = legacy['statuses_count']
         self.is_translator: bool = legacy['is_translator']
         self.translator_type: str = legacy['translator_type']
-        self.withheld_in_countries: list[str] = legacy['withheld_in_countries']
+        self.withheld_in_countries: list[str] = legacy.get('withheld_in_countries', [])
         self.protected: bool = legacy.get('protected', False)
 
     @property

--- a/twikit/guest/user.py
+++ b/twikit/guest/user.py
@@ -95,7 +95,7 @@ class User:
         self.description: str = legacy['description']
         self.description_urls: list = legacy['entities'].get('description', {}).get('urls', [])
         self.urls: list = legacy['entities'].get('url', {}).get('urls')
-        self.pinned_tweet_ids: list[str] = legacy['pinned_tweet_ids_str']
+        self.pinned_tweet_ids: list[str] = legacy.get('pinned_tweet_ids_str', [])
         self.is_blue_verified: bool = data['is_blue_verified']
         self.verified: bool = legacy['verified']
         self.possibly_sensitive: bool = legacy['possibly_sensitive']

--- a/twikit/user.py
+++ b/twikit/user.py
@@ -101,7 +101,7 @@ class User:
         self.description: str = legacy['description']
         self.description_urls: list = legacy['entities'].get('description', {}).get('urls', [])
         self.urls: list = legacy['entities'].get('url', {}).get('urls')
-        self.pinned_tweet_ids: list[str] = legacy['pinned_tweet_ids_str']
+        self.pinned_tweet_ids: list[str] = legacy.get('pinned_tweet_ids_str', [])
         self.is_blue_verified: bool = data['is_blue_verified']
         self.verified: bool = legacy['verified']
         self.possibly_sensitive: bool = legacy['possibly_sensitive']

--- a/twikit/user.py
+++ b/twikit/user.py
@@ -99,7 +99,7 @@ class User:
         self.url: str = legacy.get('url')
         self.location: str = legacy['location']
         self.description: str = legacy['description']
-        self.description_urls: list = legacy['entities']['description']['urls']
+        self.description_urls: list = legacy['entities'].get('description', {}).get('urls', [])
         self.urls: list = legacy['entities'].get('url', {}).get('urls')
         self.pinned_tweet_ids: list[str] = legacy['pinned_tweet_ids_str']
         self.is_blue_verified: bool = data['is_blue_verified']
@@ -121,7 +121,7 @@ class User:
         self.statuses_count: int = legacy['statuses_count']
         self.is_translator: bool = legacy['is_translator']
         self.translator_type: str = legacy['translator_type']
-        self.withheld_in_countries: list[str] = legacy['withheld_in_countries']
+        self.withheld_in_countries: list[str] = legacy.get('withheld_in_countries', [])
         self.protected: bool = legacy.get('protected', False)
 
     @property

--- a/twikit/x_client_transaction/transaction.py
+++ b/twikit/x_client_transaction/transaction.py
@@ -13,9 +13,9 @@ from .rotation import convert_rotation_to_matrix
 from .utils import float_to_hex, is_odd, base64_encode, handle_x_migration
 
 ON_DEMAND_FILE_REGEX = re.compile(
-    r"""['|\"]{1}ondemand\.s['|\"]{1}:\s*['|\"]{1}([\w]*)['|\"]{1}""", flags=(re.VERBOSE | re.MULTILINE))
-INDICES_REGEX = re.compile(
-    r"""(\(\w{1}\[(\d{1,2})\],\s*16\))+""", flags=(re.VERBOSE | re.MULTILINE))
+    r',(\d+):["\']ondemand\.s["\']', flags=(re.VERBOSE | re.MULTILINE))
+ON_DEMAND_HASH_PATTERN = r',{}:["\']([0-9a-f]+)["\']'
+INDICES_REGEX = re.compile(r'\[(\d+)\],\s*16')
 
 
 class ClientTransaction:
@@ -42,14 +42,17 @@ class ClientTransaction:
         key_byte_indices = []
         response = self.validate_response(
             home_page_response) or self.home_page_response
-        on_demand_file = ON_DEMAND_FILE_REGEX.search(str(response))
-        if on_demand_file:
-            on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{on_demand_file.group(1)}a.js"
-            on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
-            key_byte_indices_match = INDICES_REGEX.finditer(
-                str(on_demand_file_response.text))
-            for item in key_byte_indices_match:
-                key_byte_indices.append(item.group(2))
+        on_demand_match = ON_DEMAND_FILE_REGEX.search(str(response))
+        if on_demand_match:
+            chunk_index = on_demand_match.group(1)
+            hash_match = re.search(
+                ON_DEMAND_HASH_PATTERN.format(chunk_index), str(response))
+            if hash_match:
+                file_hash = hash_match.group(1)
+                on_demand_file_url = f"https://abs.twimg.com/responsive-web/client-web/ondemand.s.{file_hash}a.js"
+                on_demand_file_response = await session.request(method="GET", url=on_demand_file_url, headers=headers)
+                for item in INDICES_REGEX.finditer(on_demand_file_response.text):
+                    key_byte_indices.append(item.group(1))
         if not key_byte_indices:
             raise Exception("Couldn't get KEY_BYTE indices")
         key_byte_indices = list(map(int, key_byte_indices))


### PR DESCRIPTION
## Summary

- Fixes `Exception: Couldn't get KEY_BYTE indices`, which currently breaks every request (see #408, #409). X changed the webpack chunk format used to reference `ondemand.s.*.js` in the homepage HTML, so `ON_DEMAND_FILE_REGEX` no longer matches.
  - Adapted from #411 by @ryanstoic, which switches to a two-step lookup (find the chunk index for `ondemand.s`, then look up that chunk's hash separately).
  - Additionally hardened `ON_DEMAND_HASH_PATTERN` to accept both single- and double-quoted hash values — the original PR only handled double quotes, which left the same failure mode for single-quoted chunk data.
- Fixes `KeyError('urls')` / `KeyError('withheld_in_countries')` raised by `User.__init__` (both `twikit/user.py` and `twikit/guest/user.py`) when X omits `entities.description.urls` or `withheld_in_countries` from a user's legacy payload (observed for accounts with no links in their bio). Both fields now use `.get(...)` with safe defaults, matching the pattern already used for sibling optional fields like `profile_banner_url`.

## Test plan

- [x] Verified locally with real, currently-valid Twitter cookies: `Client.get_user_tweets()` now succeeds end-to-end and returns real tweet content, where it previously raised `Couldn't get KEY_BYTE indices` immediately.
- [x] Verified the `ON_DEMAND_HASH_PATTERN` quote-handling fix with a standalone regex test against both single- and double-quoted synthetic chunk data.
- [ ] Not tested against every account edge case (e.g. suspended/protected accounts) — only the two KeyError cases actually observed.

## Summary by Sourcery

Update X client transaction parsing to restore KEY_BYTE index discovery and harden against changes in ondemand webpack chunks, while making user field handling resilient to missing legacy fields and documenting this fork as a temporary community patch.

Bug Fixes:
- Restore KEY_BYTE index extraction by updating ondemand.s chunk detection and hash lookup to match X's current homepage bundle format.
- Prevent KeyError when X omits user description URL entities or withheld_in_countries in both authenticated and guest user payloads by providing safe defaults.

Documentation:
- Document this repository as an unofficial patch fork with installation instructions and a summary of the fixes included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with X’s current frontend by updating transaction processing and animation key index detection.
  * Prevented crashes when user profile legacy fields are missing by defaulting absent list values (e.g., description links, withheld countries, pinned tweet ids) to empty lists.
* **Documentation**
  * Added an “IMPORTANT” callout describing an unofficial community patch fork and clarified its best-effort, personal-maintenance status.
  * Included direct install instructions for the patched version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->